### PR TITLE
Xml entity

### DIFF
--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -159,12 +159,12 @@
       "properties": [
         {
           "name": "type",
-          "type": "string",
+          "type": "String",
           "isAttr": true
         },
         {
           "name": "retries",
-          "type": "string",
+          "type": "String",
           "isAttr": true
         }
       ]
@@ -184,22 +184,22 @@
       "properties": [
         {
           "name": "inputCollection",
-          "type": "string",
+          "type": "String",
           "isAttr": true
         },
         {
           "name": "inputElement",
-          "type": "string",
+          "type": "String",
           "isAttr": true
         },
         {
           "name": "outputCollection",
-          "type": "string",
+          "type": "String",
           "isAttr": true
         },
         {
           "name": "outputElement",
-          "type": "string",
+          "type": "String",
           "isAttr": true
         }
       ]
@@ -217,12 +217,12 @@
       "properties": [
         {
           "name": "processId",
-          "type": "string",
+          "type": "String",
           "isAttr": true
         },
         {
           "name": "processIdExpression",
-          "type": "string",
+          "type": "String",
           "isAttr": true
         },
         {
@@ -245,12 +245,12 @@
       "properties": [
         {
           "name": "id",
-          "type": "string",
+          "type": "String",
           "isAttr": true
         },
         {
           "name": "body",
-          "type": "string",
+          "type": "String",
           "isBody": true
         }
       ]
@@ -268,7 +268,7 @@
       "properties": [
         {
           "name": "formKey",
-          "type": "string",
+          "type": "String",
           "isAttr": true
         }
       ]

--- a/test/fixtures/xml/process-zeebe-userTaskForm.part.bpmn
+++ b/test/fixtures/xml/process-zeebe-userTaskForm.part.bpmn
@@ -5,5 +5,6 @@
 >
   <bpmn:extensionElements>
     <zeebe:userTaskForm id="userTaskForm-1">{ components: [ { label: "field", key: "field" } ] }</zeebe:userTaskForm>
+    <zeebe:userTaskForm id="userTaskForm-2">{ components: [ { label: "&lt;field&gt;", key: "field" } ] }</zeebe:userTaskForm>
   </bpmn:extensionElements>
 </bpmn:process>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -440,6 +440,11 @@ describe('read', function() {
                 $type: 'zeebe:UserTaskForm',
                 id: 'userTaskForm-1',
                 body: '{ components: [ { label: "field", key: "field" } ] }'
+              },
+              {
+                $type: 'zeebe:UserTaskForm',
+                id: 'userTaskForm-2',
+                body: '{ components: [ { label: "<field>", key: "field" } ] }'
               }
             ]
           }

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -145,6 +145,45 @@ describe('write', function() {
       expect(xml).to.eql(expectedXML);
     });
 
+
+    it('zeebe:userTaskForm', async function() {
+
+      // given
+      var proc = moddle.create('bpmn:Process', {
+        extensionElements: moddle.create('bpmn:ExtensionElements', {
+          values: [
+            moddle.create('zeebe:UserTaskForm', {
+              id: 'userTaskForm-1',
+              body: '{ components: [ { label: "field", key: "field" } ] }'
+            }),
+            moddle.create('zeebe:UserTaskForm', {
+              id: 'userTaskForm-2',
+              body: '{ components: [ { label: "<field>", key: "field" } ] }'
+            })
+          ]
+        })
+      });
+
+      var expectedXML =
+        '<bpmn:process xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
+                      'xmlns:zeebe="http://camunda.org/schema/zeebe/1.0">' +
+          '<bpmn:extensionElements>' +
+            '<zeebe:userTaskForm id="userTaskForm-1">' +
+              '{ components: [ { label: "field", key: "field" } ] }' +
+            '</zeebe:userTaskForm>' +
+            '<zeebe:userTaskForm id="userTaskForm-2">' +
+              '{ components: [ { label: "&lt;field&gt;", key: "field" } ] }' +
+            '</zeebe:userTaskForm>' +
+          '</bpmn:extensionElements>' +
+        '</bpmn:process>';
+
+      // when
+      const xml = await write(proc);
+
+      // then
+      expect(xml).to.eql(expectedXML);
+    });
+
   });
 
 });


### PR DESCRIPTION
Verifies XML entity encoding in body elements (not working right now) :fire:.

Builds upon https://github.com/zeebe-io/zeebe-bpmn-moddle/pull/11.