### PR TITLE
fix: restrict `taskDefinition` for `zeebeServiceTasks` only

### DIFF
--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -156,6 +156,11 @@
       "superClass": [
         "Element"
       ],
+      "meta": {
+        "allowedIn": [
+          "zeebe:ZeebeServiceTask"
+        ]
+      },
       "properties": [
         {
           "name": "type",

--- a/test/spec/extension.js
+++ b/test/spec/extension.js
@@ -496,6 +496,64 @@ describe('extension - can copy', function() {
 
   });
 
+
+  describe('<zeebe:TaskDefinition>', function() {
+
+    it('should allow on ServiceTask', function() {
+
+      // given
+      var taskDefinition = moddle.create('zeebe:TaskDefinition'),
+          serviceTask = moddle.create('bpmn:ServiceTask'),
+          extensionElements = moddle.create('bpmn:ExtensionElements');
+
+      taskDefinition.$parent = extensionElements;
+      extensionElements.$parent = serviceTask;
+
+      // when
+      var canCopyProperty = zeebeModdleExtension.canCopyProperty(taskDefinition, extensionElements);
+
+      // then
+      expect(canCopyProperty).not.to.be.false;
+    });
+
+
+    it('should not allow on Task', function() {
+
+      // given
+      var taskDefinition = moddle.create('zeebe:TaskDefinition'),
+          task = moddle.create('bpmn:Task'),
+          extensionElements = moddle.create('bpmn:ExtensionElements');
+
+      taskDefinition.$parent = extensionElements;
+      extensionElements.$parent = task;
+
+      // when
+      var canCopyProperty = zeebeModdleExtension.canCopyProperty(taskDefinition, extensionElements);
+
+      // then
+      expect(canCopyProperty).to.be.false;
+    });
+
+
+    it('should not allow on StartEvent', function() {
+
+      // given
+      var taskDefinition = moddle.create('zeebe:TaskDefinition'),
+          startEvent = moddle.create('bpmn:StartEvent'),
+          extensionElements = moddle.create('bpmn:ExtensionElements');
+
+      taskDefinition.$parent = extensionElements;
+      extensionElements.$parent = startEvent;
+
+      // when
+      var canCopyProperty = zeebeModdleExtension.canCopyProperty(taskDefinition, extensionElements);
+
+      // then
+      expect(canCopyProperty).to.be.false;
+    });
+
+  });
+
 });
 
 


### PR DESCRIPTION
__Current Situation__
* TaskDefinition property doesn't have the `meta.allowedIn` field in the zeebe.json

__Problem__
* For properties without the `meta.allowedIn` field, it is assumed to be allowed for all elements 
* Doesn't make sense since it's only present for zeebe Service Tasks 

__Solution__
* Add  `zeebeServiceTasks` in the `meta.allowedIn` field for the `taskDefinition` property in the zeebe.json