### PR TITLE
Make Message Intermediate Throw Event and Message End Event Zeebe Service Tasks

### DIFF
--- a/lib/extension.js
+++ b/lib/extension.js
@@ -6,6 +6,7 @@ var isFunction = require('min-dash').isFunction,
 
 var WILDCARD = '*';
 
+const zeebeServiceTaskProperties = [ 'zeebe:TaskDefinition', 'zeebe:Subscription', 'zeebe:TaskHeaders','zeebe:LoopCharacteristics','zeebe:Input' ];
 
 function ZeebeModdleExtension(eventBus) {
 
@@ -23,11 +24,29 @@ ZeebeModdleExtension.$inject = [ 'eventBus' ];
 
 ZeebeModdleExtension.prototype.canCopyProperty = function(property, parent) {
 
-  // check if property is allowed in parent
+  // (1) check if property is allowed in parent
   if (isObject(property) && !isAllowedInParent(property, parent)) {
-
     return false;
   }
+
+  // (2) check for specific scenarios
+  if (!this.canHostServiceTaskLikeProperties(property, parent)) {
+    return false;
+  }
+};
+
+ZeebeModdleExtension.prototype.canHostServiceTaskLikeProperties = function(property, parent) {
+
+  if (isAllowedInZeebeServiceTask(property)) {
+
+    var serviceTaskLike = getParent(parent, 'bpmn:IntermediateThrowEvent') || getParent(parent, 'bpmn:EndEvent');
+
+    if (serviceTaskLike) {
+      return isMessageEvent(serviceTaskLike);
+    }
+  }
+
+  return true;
 };
 
 module.exports = ZeebeModdleExtension;
@@ -73,4 +92,19 @@ function isAllowedInParent(property, parent) {
 
 function isWildcard(allowedIn) {
   return allowedIn.indexOf(WILDCARD) !== -1;
+}
+
+function isMessageEvent(event) {
+  const eventDefinitions = event.get('eventDefinitions');
+
+  return eventDefinitions.some(function(def) {
+    return is(def, 'bpmn:MessageEventDefinition');
+  });
+}
+
+// check if property is allowed in ZeebeServiceTask but not for none events
+function isAllowedInZeebeServiceTask(property) {
+  return zeebeServiceTaskProperties.some(function(propertyType) {
+    return is(property, propertyType);
+  });
 }

--- a/resources/zeebe.json
+++ b/resources/zeebe.json
@@ -13,7 +13,9 @@
         "bpmn:ServiceTask",
         "bpmn:BusinessRuleTask",
         "bpmn:ScriptTask",
-        "bpmn:SendTask"
+        "bpmn:SendTask",
+        "bpmn:EndEvent",
+        "bpmn:IntermediateThrowEvent"
       ],
       "properties": [
         {

--- a/test/spec/extension.js
+++ b/test/spec/extension.js
@@ -124,6 +124,46 @@ describe('extension - can copy', function() {
       expect(canCopyProperty).to.be.false;
     });
 
+
+    it('should allow on intermediateThrowEvent with messageDefinition', function() {
+
+      // given
+      var loopCharacteristics = moddle.create('zeebe:LoopCharacteristics'),
+          extensionElements = moddle.create('bpmn:ExtensionElements'),
+          messageEventDefinition = moddle.create('bpmn:MessageEventDefinition'),
+          messageIntermediateThrowEvent = moddle.create('bpmn:IntermediateThrowEvent');
+
+      extensionElements.$parent = messageIntermediateThrowEvent;
+      messageEventDefinition.$parent = messageIntermediateThrowEvent;
+      messageIntermediateThrowEvent.eventDefinitions = [messageEventDefinition];
+
+      // when
+      var canCopyProperty = zeebeModdleExtension.canCopyProperty(loopCharacteristics, extensionElements);
+
+      // then
+      expect(canCopyProperty).not.to.be.false;
+    });
+
+
+    it('should not allow on errorEndEvent', function() {
+
+      // given
+      var loopCharacteristics = moddle.create('zeebe:LoopCharacteristics'),
+          extensionElements = moddle.create('bpmn:ExtensionElements'),
+          errorEventDefinition = moddle.create('bpmn:ErrorEventDefinition'),
+          endEvent = moddle.create('bpmn:EndEvent');
+
+      extensionElements.$parent = endEvent;
+      errorEventDefinition.$parent = endEvent;
+      endEvent.eventDefinitions = [errorEventDefinition];
+
+      // when
+      var canCopyProperty = zeebeModdleExtension.canCopyProperty(loopCharacteristics, extensionElements);
+
+      // then
+      expect(canCopyProperty).to.be.false;
+    });
+
   });
 
 
@@ -183,6 +223,45 @@ describe('extension - can copy', function() {
 
       // then
       expect(canCopyProperty).to.be.false;
+    });
+
+    it('should not allow on NoneEndEvents', function() {
+
+      // given
+      var ioMapping = moddle.create('zeebe:IoMapping'),
+          input = moddle.create('zeebe:Input'),
+          endEvent = moddle.create('bpmn:EndEvent'),
+          extensionElements = moddle.create('bpmn:ExtensionElements');
+
+      ioMapping.$parent = extensionElements;
+      extensionElements.$parent = endEvent;
+
+      // when
+      var canCopyProperty = zeebeModdleExtension.canCopyProperty(input, extensionElements);
+
+      // then
+      expect(canCopyProperty).to.be.false;
+    });
+
+    it('should allow on MessageEndEvents', function() {
+
+      // given
+      var ioMapping = moddle.create('zeebe:IoMapping'),
+          input = moddle.create('zeebe:Input'),
+          messageEndEvent = moddle.create('bpmn:EndEvent'),
+          messageEventDefinition = moddle.create('bpmn:MessageEventDefinition'),
+          extensionElements = moddle.create('bpmn:ExtensionElements');
+
+      ioMapping.$parent = extensionElements;
+      extensionElements.$parent = messageEndEvent;
+      messageEventDefinition.$parent = messageEndEvent;
+      messageEndEvent.eventDefinitions = [messageEventDefinition];
+
+      // when
+      var canCopyProperty = zeebeModdleExtension.canCopyProperty(input, extensionElements);
+
+      // then
+      expect(canCopyProperty).to.not.be.false;
     });
 
   });
@@ -263,6 +342,45 @@ describe('extension - can copy', function() {
 
       // then
       expect(canCopyProperty).to.be.false;
+    });
+
+    it('should allow on NoneEndEvents', function() {
+
+      // given
+      var ioMapping = moddle.create('zeebe:IoMapping'),
+          output = moddle.create('zeebe:Output'),
+          endEvent = moddle.create('bpmn:EndEvent'),
+          extensionElements = moddle.create('bpmn:ExtensionElements');
+
+      ioMapping.$parent = extensionElements;
+      extensionElements.$parent = endEvent;
+
+      // when
+      var canCopyProperty = zeebeModdleExtension.canCopyProperty(output, extensionElements);
+
+      // then
+      expect(canCopyProperty).to.not.be.false;
+    });
+
+    it('should allow on MessageEndEvents', function() {
+
+      // given
+      var ioMapping = moddle.create('zeebe:IoMapping'),
+          output = moddle.create('zeebe:Output'),
+          messageEndEvent = moddle.create('bpmn:EndEvent'),
+          messageEventDefinition = moddle.create('bpmn:MessageEventDefinition'),
+          extensionElements = moddle.create('bpmn:ExtensionElements');
+
+      ioMapping.$parent = extensionElements;
+      extensionElements.$parent = messageEndEvent;
+      messageEventDefinition.$parent = messageEndEvent;
+      messageEndEvent.eventDefinitions = [messageEventDefinition];
+
+      // when
+      var canCopyProperty = zeebeModdleExtension.canCopyProperty(output, extensionElements);
+
+      // then
+      expect(canCopyProperty).to.not.be.false;
     });
 
   });
@@ -544,6 +662,43 @@ describe('extension - can copy', function() {
 
       taskDefinition.$parent = extensionElements;
       extensionElements.$parent = startEvent;
+
+      // when
+      var canCopyProperty = zeebeModdleExtension.canCopyProperty(taskDefinition, extensionElements);
+
+      // then
+      expect(canCopyProperty).to.be.false;
+    });
+
+
+    it('should allow on endEvent with messageDefinition', function() {
+
+      // given
+      var taskDefinition = moddle.create('zeebe:TaskDefinition'),
+          extensionElements = moddle.create('bpmn:ExtensionElements'),
+          messageEventDefinition = moddle.create('bpmn:MessageEventDefinition'),
+          messageEndEvent = moddle.create('bpmn:EndEvent');
+
+      extensionElements.$parent = messageEndEvent;
+      messageEventDefinition.$parent = messageEndEvent;
+      messageEndEvent.eventDefinitions = [messageEventDefinition];
+
+      // when
+      var canCopyProperty = zeebeModdleExtension.canCopyProperty(taskDefinition, extensionElements);
+
+      // then
+      expect(canCopyProperty).not.to.be.false;
+    });
+
+
+    it('should not allow on endEvent without messageDefinition', function() {
+
+      // given
+      var taskDefinition = moddle.create('zeebe:TaskDefinition'),
+          extensionElements = moddle.create('bpmn:ExtensionElements'),
+          endEvent = moddle.create('bpmn:EndEvent');
+
+      extensionElements.$parent = endEvent;
 
       // when
       var canCopyProperty = zeebeModdleExtension.canCopyProperty(taskDefinition, extensionElements);


### PR DESCRIPTION
- Make  Message Intermediate Throw Event and Message End Event `zeebeServiceTask`
- Tweak `canCopyProperty` behaviour to ensure only message End Events and Intermediate Throw Events (with message definitions) are able to host `zeebeServiceTask` properties

Related to https://github.com/camunda/camunda-modeler/issues/2420