### PR TITLE
chore: change links from zeebe-io to camunda-cloud org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zeebe-bpmn-moddle
 
-[![CI](https://github.com/zeebe-io/zeebe-bpmn-moddle/workflows/CI/badge.svg)](https://github.com/zeebe-io/zeebe-bpmn-moddle/actions?query=workflow%3ACI)
+[![CI](https://github.com/camunda-cloud/zeebe-bpmn-moddle/workflows/CI/badge.svg)](https://github.com/camunda-cloud/zeebe-bpmn-moddle/actions?query=workflow%3ACI)
 
 This project defines the [Zeebe](https://zeebe.io) namespace extensions for BPMN 2.0 as a [moddle](https://github.com/bpmn-io/moddle) descriptor.
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/zeebe-io/zeebe-bpmn-moddle"
+    "url": "https://github.com/camunda-cloud/zeebe-bpmn-moddle"
   },
   "keywords": [
     "bpmn",


### PR DESCRIPTION
* After this commit, I will move the repo to camunda-cloud org

related to bpmn-io/internal-docs#292